### PR TITLE
Fix config_files metadata field

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -5,7 +5,7 @@ script_dir =  build/scripts/VR/UAP
 build_command = ./configure --bro-dist=%(bro_dist)s  && make
 test_command = ( cd tests && btest -d )
 plugin_dir = build
-config_files = scripts/init.bro
+config_files = build/scripts/init.bro
 version = 0.1
 depends =
   bro >=2.5.0


### PR DESCRIPTION
This is just my suggestion from https://github.com/bro/package-manager/issues/26.  Without this change, bro-pkg won't correctly recognize it as a config file and so changes made to it by users may be overwritten when upgrading the package.