### PR TITLE
Remove version from show-plugin btest in prep for 2.7

### DIFF
--- a/tests/Baseline/uap.show-plugin/output
+++ b/tests/Baseline/uap.show-plugin/output
@@ -1,4 +1,4 @@
-VR::UAP - User Agent Parser - Bro implementation based on uap-core (dynamic, version 0.1)
+VR::UAP - User Agent Parser - Bro implementation based on uap-core (dynamic, version)
     [Constant] UAP::uap_core_regex_path
     [Function] UAP::parse
     [Type] UAP::DeviceRec

--- a/tests/uap/show-plugin.bro
+++ b/tests/uap/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN VR::UAP >output
+# @TEST-EXEC: bro -NN VR::UAP |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.